### PR TITLE
Fix call `rb_raise`, for build with "gcc -Werror=format-security"

### DIFF
--- a/ext/fast_aes.c
+++ b/ext/fast_aes.c
@@ -96,7 +96,7 @@ VALUE fast_aes_initialize(VALUE self, VALUE key)
             break;
         default:
                         sprintf(error_mesg, "AES key must be 128, 192, or 256 bits in length (got %d): %s", key_bits, key_data);
-            rb_raise(rb_eArgError, error_mesg);
+            rb_raise(rb_eArgError, "%s", error_mesg);
             return Qnil;
     }
 


### PR DESCRIPTION
Hi, 

Please apply this commit for build Debian/Ubuntu packages.

Best Wishes,
Youhei
Signed-off-by: Youhei SASAKI uwabami@gfd-dennou.org
